### PR TITLE
V,Verilog: add a selector for ".v" files

### DIFF
--- a/Units/parser-verilog.r/verilog-github624.d/args.ctags
+++ b/Units/parser-verilog.r/verilog-github624.d/args.ctags
@@ -1,1 +1,3 @@
 --sort=no
+# The input is too short. selectVorVerilogByKeywords() doesn't work well.
+--language-force=Verilog

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -31,6 +31,9 @@ const char *
 selectLispOrLEXByLEXMarker (struct _MIO *, langType *, unsigned int);
 
 const char *
+selectVorVerilogByKeywords (struct _MIO *, langType *, unsigned int);
+
+const char *
 selectByXpathFileSpec (struct _MIO *input, langType *candidates, unsigned int nCandidates);
 
 #endif

--- a/parsers/v.c
+++ b/parsers/v.c
@@ -28,6 +28,7 @@
 #include "field.h"
 #include "htable.h"
 #include "param.h"
+#include "selectors.h"
 
 #define MAX_REPLAYS 2
 #define _NARGS(_1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
@@ -2876,12 +2877,14 @@ extern parserDefinition *VParser (void)
 {
 	static const char *const extensions[] = { "v", NULL };
 	parserDefinition *def = parserNew ("V");
+	static selectLanguage selectors[] = { selectVorVerilogByKeywords, NULL };
 	def->kindTable = VKinds;
 	def->kindCount = ARRAY_SIZE (VKinds);
 	def->extensions = extensions;
 	def->parser = findVTags;
 	def->initialize = initialize;
 	def->finalize = finalize;
+	def->selectLanguage  = selectors;
 	def->keywordTable = VKeywordTable;
 	def->keywordCount = ARRAY_SIZE (VKeywordTable);
 	def->fieldTable = VFields;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -32,6 +32,7 @@
 #include "parse.h"
 #include "read.h"
 #include "routines.h"
+#include "selectors.h"
 #include "xtag.h"
 #include "ptrarray.h"
 
@@ -2116,6 +2117,7 @@ extern parserDefinition* VerilogParser (void)
 {
 	static const char *const extensions [] = { "v", NULL };
 	parserDefinition* def = parserNew ("Verilog");
+	static selectLanguage selectors[] = { selectVorVerilogByKeywords, NULL };
 	def->versionCurrent = 1;
 	def->versionAge = 1;
 	def->kindTable  = VerilogKinds;
@@ -2125,6 +2127,7 @@ extern parserDefinition* VerilogParser (void)
 	def->extensions = extensions;
 	def->parser     = findVerilogTags;
 	def->initialize = initializeVerilog;
+	def->selectLanguage  = selectors;
 	return def;
 }
 


### PR DESCRIPTION
This is an example of a selector.
If you have a good keyword to distinguish V and Verilog source files, modify the commit in this pull request.