### PR TITLE
V parser+foreign tags

### DIFF
--- a/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
@@ -23,9 +23,11 @@
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_ROLE_DESCRIPTION!C!function	foreigndecl	/declared in foreign languages/
 !_TAG_ROLE_DESCRIPTION!C!header	local	/local header/
 !_TAG_ROLE_DESCRIPTION!C!header	system	/system header/
 !_TAG_ROLE_DESCRIPTION!C!macro	undef	/undefined/
+!_TAG_ROLE_DESCRIPTION!C!struct	foreigndecl	/declared in foreign languages/
 main	input.c	/^int main (void) { return 0; }$/
 # option:  --format=2
 !_TAG_EXTRA_DESCRIPTION	pseudo	/Include pseudo tags/;"	extras:pseudo
@@ -52,7 +54,9 @@ main	input.c	/^int main (void) { return 0; }$/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//;"	extras:pseudo
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/;"	extras:pseudo
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/;"	extras:pseudo
+!_TAG_ROLE_DESCRIPTION!C!function	foreigndecl	/declared in foreign languages/;"	extras:pseudo
 !_TAG_ROLE_DESCRIPTION!C!header	local	/local header/;"	extras:pseudo
 !_TAG_ROLE_DESCRIPTION!C!header	system	/system header/;"	extras:pseudo
 !_TAG_ROLE_DESCRIPTION!C!macro	undef	/undefined/;"	extras:pseudo
+!_TAG_ROLE_DESCRIPTION!C!struct	foreigndecl	/declared in foreign languages/;"	extras:pseudo
 main	input.c	/^int main (void) { return 0; }$/

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -82,7 +82,7 @@
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "m,member", "pattern": "class members"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "v,variable", "pattern": "variables"}
 {"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combineV2"}
-{"_type": "ptag", "name": "TAG_PARSER_VERSION", "parserName": "C", "path": "0.0", "pattern": "current.age"}
+{"_type": "ptag", "name": "TAG_PARSER_VERSION", "parserName": "C", "path": "1.1", "pattern": "current.age"}
 {"_type": "ptag", "name": "TAG_PARSER_VERSION", "parserName": "Go", "path": "0.0", "pattern": "current.age"}
 {"_type": "ptag", "name": "TAG_PARSER_VERSION", "parserName": "Man", "path": "0.0", "pattern": "current.age"}
 {"_type": "ptag", "name": "TAG_PARSER_VERSION", "parserName": "Python", "path": "0.0", "pattern": "current.age"}
@@ -90,9 +90,11 @@
 {"_type": "ptag", "name": "TAG_PROGRAM_AUTHOR", "path": "Universal Ctags Team", "pattern": ""}
 {"_type": "ptag", "name": "TAG_PROGRAM_NAME", "path": "Universal Ctags", "pattern": "Derived from Exuberant Ctags"}
 {"_type": "ptag", "name": "TAG_PROGRAM_URL", "path": "https://ctags.io/", "pattern": "official site"}
+{"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "C", "kindName": "function", "path": "foreigndecl", "pattern": "declared in foreign languages"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "C", "kindName": "header", "path": "local", "pattern": "local header"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "C", "kindName": "header", "path": "system", "pattern": "system header"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "C", "kindName": "macro", "path": "undef", "pattern": "undefined"}
+{"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "C", "kindName": "struct", "path": "foreigndecl", "pattern": "declared in foreign languages"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "Go", "kindName": "package", "path": "imported", "pattern": "imported package"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "Go", "kindName": "unknown", "path": "receiverType", "pattern": "receiver type"}
 {"_type": "ptag", "name": "TAG_ROLE_DESCRIPTION", "parserName": "Python", "kindName": "module", "path": "imported", "pattern": "imported modules"}

--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -3,13 +3,13 @@ D	macroparam	no	no	0	C	parameters inside macro definitions
 L	label	no	no	0	C	goto labels
 d	macro	yes	no	2	C	macro definitions
 e	enumerator	yes	no	0	C	enumerators (values inside an enumeration)
-f	function	yes	no	0	C	function definitions
+f	function	yes	no	1	C	function definitions
 g	enum	yes	no	0	C	enumeration names
 h	header	yes	yes	2	C	included header files
 l	local	no	no	0	C	local variables
 m	member	yes	no	0	C	struct, and union members
 p	prototype	no	no	0	C	function prototypes
-s	struct	yes	no	0	C	structure names
+s	struct	yes	no	1	C	structure names
 t	typedef	yes	no	0	C	typedefs
 u	union	yes	no	0	C	union names
 v	variable	yes	no	0	C	variable definitions

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -20,8 +20,10 @@ Basic          f/function        decl               on      declared
 Bats           S/script          loaded             on      script loaed with "load" command
 C              d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C              d/macro           undef              on      undefined
+C              f/function        foreigndecl        on      declared in foreign languages
 C              h/header          local              on      local header
 C              h/header          system             on      system header
+C              s/struct          foreigndecl        on      declared in foreign languages
 C++            d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro           undef              on      undefined
 C++            h/header          local              on      local header
@@ -143,8 +145,10 @@ Basic          f/function        decl               on      declared
 Bats           S/script          loaded             on      script loaed with "load" command
 C              d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C              d/macro           undef              on      undefined
+C              f/function        foreigndecl        on      declared in foreign languages
 C              h/header          local              on      local header
 C              h/header          system             on      system header
+C              s/struct          foreigndecl        on      declared in foreign languages
 C++            d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro           undef              on      undefined
 C++            h/header          local              on      local header
@@ -248,11 +252,13 @@ Zsh            s/script          loaded             on      loaded
 #
 # C.*
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # all.d
@@ -285,49 +291,59 @@ s/script   loaded on      loaded
 #
 # C.* with disabling all roles of all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # C.* with disabling all roles of all kinds of all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # C.* with enabling all roles of all kinds in all languages
 # after disabling system role of header kind of C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition on      used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   on      used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling all roles in all languages
 # after disabling system role of header kind of C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition on      used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   on      used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with disabling all roles in C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # Sh.* with disabling all roles in C language
@@ -339,11 +355,13 @@ s/script   loaded    on      loaded
 #
 # C.* with disabling all roles of all kinds in C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # Sh.* with disabling all roles of all kinds in C language
@@ -356,11 +374,13 @@ s/script   loaded    on      loaded
 # C.* with enabling all roles in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition on      used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   on      used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # Sh.* with enabling all roles in C language
@@ -374,11 +394,13 @@ s/script   loaded    off     loaded
 # C.* with enabling all roles of all kinds in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition on      used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   on      used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # Sh.* with enabling all roles of all kinds in C language
@@ -391,11 +413,13 @@ s/script   loaded    off     loaded
 #
 # C.* with disabling all roles of {header} kind in C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # Sh.* with disabling all roles of {header} kind in C language
@@ -407,11 +431,13 @@ s/script   loaded    on      loaded
 #
 # C.* with disabling all roles of h kind in C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # Sh.* with disabling all roles of h kind in C language
@@ -424,11 +450,13 @@ s/script   loaded    on      loaded
 # C.* with enabling all roles of {header} kind in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # Sh.* with enabling all roles of {header} kind in C language
@@ -442,11 +470,13 @@ s/script   loaded    off     loaded
 # C.* with enabling all roles of h kind in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # Sh.* with enabling all roles of h kind in C language
@@ -459,109 +489,133 @@ s/script   loaded    off     loaded
 #
 # C.* with disabling system role of h kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with disabling system role of {header} kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling system role of h kind after disabling the role
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling system role of {header} kind after disabling the role
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with disabling system and local roles of h kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with disabling system and local roles of {header} kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     off     local header
-h/header   system    off     system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       off     local header
+h/header    system      off     system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling system and local roles of h kind
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # C.* with enabling system and local roles of {header} kind
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # C.* with disabling local role of h kind and undef role of d kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     off     local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       off     local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kind
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     on      undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       on      undefined
+f/function  foreigndecl on      declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl on      declared in foreign languages
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kinds of C language
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kinds of C language (short notation)
 #
-#KIND(L/N) NAME      ENABLED DESCRIPTION
-d/macro    condition off     used in part of #if/#ifdef/#elif conditions
-d/macro    undef     off     undefined
-h/header   local     on      local header
-h/header   system    on      system header
+#KIND(L/N)  NAME        ENABLED DESCRIPTION
+d/macro     condition   off     used in part of #if/#ifdef/#elif conditions
+d/macro     undef       off     undefined
+f/function  foreigndecl off     declared in foreign languages
+h/header    local       on      local header
+h/header    system      on      system header
+s/struct    foreigndecl off     declared in foreign languages

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -109,8 +109,8 @@ Tex            i/xinput          included           on      external input file 
 Tex            i/xinput          input              on      external input file specified with \input
 Thrift         T/thriftFile      included           on      included file
 V              Y/unknown         imported           on      imported symbol
+V              p/module          foreignlang        on      representing a foreign language (i.e., C, JS...)
 V              p/module          imported           on      imported module
-V              x/extern          extern             on      external symbol
 VHDL           e/entity          desigend           on      designed by an architecture
 Vera           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro           undef              on      undefined
@@ -232,8 +232,8 @@ Tex            i/xinput          included           on      external input file 
 Tex            i/xinput          input              on      external input file specified with \input
 Thrift         T/thriftFile      included           on      included file
 V              Y/unknown         imported           on      imported symbol
+V              p/module          foreignlang        on      representing a foreign language (i.e., C, JS...)
 V              p/module          imported           on      imported module
-V              x/extern          extern             on      external symbol
 VHDL           e/entity          desigend           on      designed by an architecture
 Vera           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro           undef              on      undefined

--- a/Tmain/nested-subparsers.d/stdout-expected.txt
+++ b/Tmain/nested-subparsers.d/stdout-expected.txt
@@ -38,13 +38,13 @@ D       macroparam no      no      0      C      parameters inside macro definit
 L       label      no      no      0      C      goto labels
 d       macro      yes     no      2      C      macro definitions
 e       enumerator yes     no      0      C      enumerators (values inside an enumeration)
-f       function   yes     no      0      C      function definitions
+f       function   yes     no      1      C      function definitions
 g       enum       yes     no      0      C      enumeration names
 h       header     yes     yes     2      C      included header files
 l       local      no      no      0      C      local variables
 m       member     yes     no      0      C      struct, and union members
 p       prototype  no      no      0      C      function prototypes
-s       struct     yes     no      0      C      structure names
+s       struct     yes     no      1      C      structure names
 t       typedef    yes     no      0      C      typedefs
 u       union      yes     no      0      C      union names
 v       variable   yes     no      0      C      variable definitions

--- a/Tmain/version-option.d/stdout-expected.txt
+++ b/Tmain/version-option.d/stdout-expected.txt
@@ -1,1 +1,1 @@
-parser/C: 0.0
+parser/C: 1.1

--- a/Units/parser-v.r/torture.d/args.ctags
+++ b/Units/parser-v.r/torture.d/args.ctags
@@ -1,3 +1,3 @@
---fields=+ERSaenr
+--fields=+ERSaenrl
 --sort=no
 --extras=+r

--- a/Units/parser-v.r/torture.d/expected.tags
+++ b/Units/parser-v.r/torture.d/expected.tags
@@ -1,7 +1,9 @@
 main	input.v	/^fn main() {$/;"	f	line:1	typeref:typename:	signature:()	roles:def	end:17
 a	input.v	/^	a := 1$/;"	v	line:3	fn:main	roles:def
-SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	extern:C	roles:def	end:2
-foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	extern:C	typeref:typename:i64	signature:(bar string)	roles:def
+C	input-1.v	/^struct C.SYSTEM_INFO {$/;"	p	line:1	roles:foreignlang	extras:reference
+SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	module:C	roles:def	end:2
+C	input-1.v	/^fn C.foo(bar string) i64$/;"	p	line:3	roles:foreignlang	extras:reference
+foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	module:C	typeref:typename:i64	signature:(bar string)	roles:def
 thismodule	input-2.v	/^module thismodule$/;"	p	line:1	roles:def
 that	input-2.v	/^import that.aaa$/;"	p	line:3	roles:imported	extras:reference
 aaa	input-2.v	/^import that.aaa$/;"	p	line:3	module:that	roles:imported	extras:reference

--- a/Units/parser-v.r/torture.d/expected.tags
+++ b/Units/parser-v.r/torture.d/expected.tags
@@ -1,17 +1,17 @@
-main	input.v	/^fn main() {$/;"	f	line:1	typeref:typename:	signature:()	roles:def	end:17
-a	input.v	/^	a := 1$/;"	v	line:3	fn:main	roles:def
-C	input-1.v	/^struct C.SYSTEM_INFO {$/;"	p	line:1	roles:foreignlang	extras:reference
-SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	module:C	roles:def	end:2
-C	input-1.v	/^fn C.foo(bar string) i64$/;"	p	line:3	roles:foreignlang	extras:reference
-foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	module:C	typeref:typename:i64	signature:(bar string)	roles:def
-thismodule	input-2.v	/^module thismodule$/;"	p	line:1	roles:def
-that	input-2.v	/^import that.aaa$/;"	p	line:3	roles:imported	extras:reference
-aaa	input-2.v	/^import that.aaa$/;"	p	line:3	module:that	roles:imported	extras:reference
-that	input-2.v	/^import that.bbb { Bbb }$/;"	p	line:4	roles:imported	extras:reference
-bbb	input-2.v	/^import that.bbb { Bbb }$/;"	p	line:4	module:that	roles:imported	extras:reference
-Bbb	input-2.v	/^import that.bbb { Bbb }$/;"	Y	line:4	module:that.bbb	roles:imported	extras:reference
-Foo	input-2.v	/^struct Foo {$/;"	s	line:6	module:thismodule	roles:def	end:9
-a	input-2.v	/^	a aaa.Aaa$/;"	m	line:7	struct:thismodule.Foo	roles:def
-b	input-2.v	/^	b Bbb$/;"	m	line:8	struct:thismodule.Foo	roles:def
-main	input-2.v	/^fn main() {$/;"	f	line:11	module:thismodule	typeref:typename:	signature:()	roles:def	end:15
-foo	input-2.v	/^	foo := Foo{}$/;"	v	line:12	fn:thismodule.main	roles:def
+main	input.v	/^fn main() {$/;"	f	line:1	language:V	typeref:typename:	signature:()	roles:def	end:17
+a	input.v	/^	a := 1$/;"	v	line:3	language:V	fn:main	roles:def
+C	input-1.v	/^struct C.SYSTEM_INFO {$/;"	p	line:1	language:V	roles:foreignlang	extras:reference
+SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	language:V	module:C	roles:def	end:2
+C	input-1.v	/^fn C.foo(bar string) i64$/;"	p	line:3	language:V	roles:foreignlang	extras:reference
+foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	language:V	module:C	typeref:typename:i64	signature:(bar string)	roles:def
+thismodule	input-2.v	/^module thismodule$/;"	p	line:1	language:V	roles:def
+that	input-2.v	/^import that.aaa$/;"	p	line:3	language:V	roles:imported	extras:reference
+aaa	input-2.v	/^import that.aaa$/;"	p	line:3	language:V	module:that	roles:imported	extras:reference
+that	input-2.v	/^import that.bbb { Bbb }$/;"	p	line:4	language:V	roles:imported	extras:reference
+bbb	input-2.v	/^import that.bbb { Bbb }$/;"	p	line:4	language:V	module:that	roles:imported	extras:reference
+Bbb	input-2.v	/^import that.bbb { Bbb }$/;"	Y	line:4	language:V	module:that.bbb	roles:imported	extras:reference
+Foo	input-2.v	/^struct Foo {$/;"	s	line:6	language:V	module:thismodule	roles:def	end:9
+a	input-2.v	/^	a aaa.Aaa$/;"	m	line:7	language:V	struct:thismodule.Foo	roles:def
+b	input-2.v	/^	b Bbb$/;"	m	line:8	language:V	struct:thismodule.Foo	roles:def
+main	input-2.v	/^fn main() {$/;"	f	line:11	language:V	module:thismodule	typeref:typename:	signature:()	roles:def	end:15
+foo	input-2.v	/^	foo := Foo{}$/;"	v	line:12	language:V	fn:thismodule.main	roles:def

--- a/Units/parser-v.r/torture.d/expected.tags
+++ b/Units/parser-v.r/torture.d/expected.tags
@@ -2,8 +2,10 @@ main	input.v	/^fn main() {$/;"	f	line:1	language:V	typeref:typename:	signature:(
 a	input.v	/^	a := 1$/;"	v	line:3	language:V	fn:main	roles:def
 C	input-1.v	/^struct C.SYSTEM_INFO {$/;"	p	line:1	language:V	roles:foreignlang	extras:reference
 SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	language:V	module:C	roles:def	end:2
+SYSTEM_INFO	input-1.v	/^struct C.SYSTEM_INFO {$/;"	s	line:1	language:C	roles:foreigndecl	extras:reference
 C	input-1.v	/^fn C.foo(bar string) i64$/;"	p	line:3	language:V	roles:foreignlang	extras:reference
 foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	language:V	module:C	typeref:typename:i64	signature:(bar string)	roles:def
+C.foo	input-1.v	/^fn C.foo(bar string) i64$/;"	f	line:3	language:C	roles:foreigndecl	extras:reference
 thismodule	input-2.v	/^module thismodule$/;"	p	line:1	language:V	roles:def
 that	input-2.v	/^import that.aaa$/;"	p	line:3	language:V	roles:imported	extras:reference
 aaa	input-2.v	/^import that.aaa$/;"	p	line:3	language:V	module:that	roles:imported	extras:reference

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -29,6 +29,7 @@ GEN_IN_MAN_FILES = \
 	\
 	ctags-lang-asm.7 \
 	ctags-lang-autoit.7 \
+	ctags-lang-c.7 \
 	ctags-lang-elm.7 \
 	ctags-lang-fortran.7 \
 	ctags-lang-gdscript.7 \

--- a/man/ctags-lang-c.7.rst.in
+++ b/man/ctags-lang-c.7.rst.in
@@ -1,0 +1,36 @@
+.. _ctags-lang-C(7):
+
+==============================================================
+ctags-lang-C
+==============================================================
+---------------------------------------------------------------------
+Random notes about tagging C source code with Universal Ctags
+---------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+C ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=C ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-C=+.c ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging C source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New role ``foreigndecl`` for ``function`` kind
+
+* New role ``foreigndecl`` for ``struct`` kind
+
+SEE ALSO
+--------
+ctags(1),
+`The new C/C++ parser <https://docs.ctags.io/en/latest/parser-cxx.html>`_ (https://docs.ctags.io/en/latest/parser-cxx.html)

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -95,6 +95,9 @@ parserDefinition * CParser (void)
 	def->selectLanguage = selectors;
 	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
+	def->versionCurrent = 1;
+	def->versionAge = 1;
+
 	return def;
 }
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -39,13 +39,35 @@ CXX_COMMON_HEADER_ROLES(C);
 CXX_COMMON_HEADER_ROLES(CXX);
 CXX_COMMON_HEADER_ROLES(CUDA);
 
+/* Currently V parser wants these items. */
+#define RoleTemplateForeignDecl { true, "foreigndecl", "declared in foreign languages" }
+
+#define CXX_COMMON_FUNCTION_ROLES(__langPrefix) \
+	static roleDefinition __langPrefix##FunctionRoles [] = { \
+		RoleTemplateForeignDecl, \
+	}
+
+CXX_COMMON_FUNCTION_ROLES(C);
+static roleDefinition CXXFunctionRoles [] = {};
+static roleDefinition CUDAFunctionRoles [] = {};
+
+#define CXX_COMMON_STRUCT_ROLES(__langPrefix) \
+	static roleDefinition __langPrefix##StructRoles [] = { \
+		RoleTemplateForeignDecl, \
+	}
+
+CXX_COMMON_STRUCT_ROLES(C);
+static roleDefinition CXXStructRoles [] = {};
+static roleDefinition CUDAStructRoles [] = {};
+
 
 #define CXX_COMMON_KINDS(_langPrefix, _szMemberDescription, _syncWith)	\
 	{ true,  'd', "macro",      "macro definitions", \
 			.referenceOnly = false, ATTACH_ROLES(_langPrefix##MacroRoles), .syncWith = _syncWith \
 	}, \
 	{ true,  'e', "enumerator", "enumerators (values inside an enumeration)", .syncWith = _syncWith }, \
-	{ true,  'f', "function",   "function definitions", .syncWith = _syncWith },		\
+	{ true,  'f', "function",   "function definitions", \
+			.referenceOnly = false, ATTACH_ROLES(_langPrefix##FunctionRoles), .syncWith = _syncWith }, \
 	{ true,  'g', "enum",       "enumeration names", .syncWith = _syncWith },		\
 	{ true, 'h', "header",     "included header files", \
 			.referenceOnly = true,  ATTACH_ROLES(_langPrefix##HeaderRoles), .syncWith = _syncWith \
@@ -53,7 +75,8 @@ CXX_COMMON_HEADER_ROLES(CUDA);
 	{ false, 'l', "local",      "local variables", .syncWith = _syncWith },   \
 	{ true,  'm', "member",     _szMemberDescription, .syncWith = _syncWith },	\
 	{ false, 'p', "prototype",  "function prototypes", .syncWith = _syncWith },		\
-	{ true,  's', "struct",     "structure names", .syncWith = _syncWith },		\
+	{ true,  's', "struct",     "structure names", \
+			.referenceOnly = false, ATTACH_ROLES(_langPrefix##StructRoles), .syncWith = _syncWith }, \
 	{ true,  't', "typedef",    "typedefs", .syncWith = _syncWith },			\
 	{ true,  'u', "union",      "union names", .syncWith = _syncWith },			\
 	{ true,  'v', "variable",   "variable definitions", .syncWith = _syncWith },		\

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -207,6 +207,14 @@ typedef enum {
 	CR_HEADER_LOCAL,
 } cHeaderRole;
 
+typedef enum {
+	CXXTagFUNCTIONRoleFOREIGNDECL,
+} CXXTagCFunctionRole;
+
+typedef enum {
+	CXXTagSTRUCTRoleFOREIGNDECL,
+} CXXTagCStructRole;
+
 // Initialize the parser state for the specified language.
 // Must be called before attempting to access the kind options.
 void cxxTagInitForLanguage(langType eLangType);

--- a/parsers/v.c
+++ b/parsers/v.c
@@ -30,6 +30,9 @@
 #include "param.h"
 #include "selectors.h"
 
+#include "dependency.h"
+#include "cxx/cxx_tag.h"
+
 #define MAX_REPLAYS 3
 #define _NARGS(_1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
 #define nArgs(...) _NARGS (__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1)
@@ -992,6 +995,47 @@ static int makeRefTag (tokenInfo *const token, vString *const name,
 						role, NULL, NULL, NULL);
 }
 
+static void makeTagForeigndeclMaybe (int scope, tokenInfo *const token, kindType kind)
+{
+	tagEntryInfo *scopeEntry = getEntryInCorkQueue (scope);
+
+	if (!scopeEntry)
+		return;
+
+	if (! (scopeEntry->langType == Lang_v &&
+		   scopeEntry->kindIndex == KIND_MODULE &&
+		   isRoleAssigned (scopeEntry, ROLE_FOREIGNLANG_MODULE)))
+		return;
+
+	if (strcmp (scopeEntry->name, "C") == 0)
+	{
+		int fk;
+		int fr;
+
+		if (kind == KIND_STRUCT)
+		{
+			fk = CXXTagKindSTRUCT;
+			fr = CXXTagSTRUCTRoleFOREIGNDECL;
+		}
+		else if (kind == KIND_FUNCTION)
+		{
+			fk = CXXTagKindFUNCTION;
+			fr = CXXTagFUNCTIONRoleFOREIGNDECL;
+		}
+		else
+			return;
+
+		tagEntryInfo foreigndecl;
+		initForeignRefTagEntry (&foreigndecl,
+								vStringValue (token->string),
+								getNamedLanguage ("C", 0),
+								fk, fr);
+		foreigndecl.lineNumber = token->lineNumber;
+		foreigndecl.filePosition = token->filePosition;
+		makeTagEntry (&foreigndecl);
+	}
+}
+
 static tokenType getOpen (tokenType close)
 {
 	switch (close)
@@ -1558,6 +1602,17 @@ static void parseFunction (tokenInfo *const token, int scope,
 				lookupQualifiedName (fnToken, name, scope, NULL) : scope;
 			newScope = makeFnTag (fnToken, name, realKind, realScope,
 								  argList, retType, access);
+			{
+				vString *tmp = fnToken->string;
+				if (name)
+					fnToken->string = name;
+				makeTagForeigndeclMaybe (realScope,
+										 fnToken,
+										 realKind);
+				if (name)
+					fnToken->string = tmp;
+			}
+
 			if (receiver)
 				makeTag (rxToken, NULL, KIND_RECEIVER, newScope);
 		}
@@ -1844,6 +1899,7 @@ static void parseStruct (tokenInfo *const token, vString *const access,
 			scope = lookupQualifiedName (token, NULL, scope, false);
 			kindType realKind = kind == KIND_NONE? KIND_STRUCT : kind;
 			newScope = makeTagEx (token, NULL, realKind, scope, access);
+			makeTagForeigndeclMaybe (scope, token, realKind);
 			registerEntry (newScope);
 			readToken (token);
 		}
@@ -2968,6 +3024,9 @@ extern parserDefinition *VParser (void)
 	static const char *const extensions[] = { "v", NULL };
 	parserDefinition *def = parserNew ("V");
 	static selectLanguage selectors[] = { selectVOrVerilogByKeywords, NULL };
+	static parserDependency dependencies [] = {
+		[0] = { DEPTYPE_FOREIGNER, "C", NULL },
+	};
 	def->kindTable = VKinds;
 	def->kindCount = ARRAY_SIZE (VKinds);
 	def->extensions = extensions;
@@ -2979,5 +3038,7 @@ extern parserDefinition *VParser (void)
 	def->keywordCount = ARRAY_SIZE (VKeywordTable);
 	def->useCork = CORK_QUEUE | CORK_SYMTAB;
 	def->requestAutomaticFQTag = true;
+	def->dependencies = dependencies;
+	def->dependencyCount = ARRAY_SIZE (dependencies);
 	return def;
 }

--- a/parsers/v.c
+++ b/parsers/v.c
@@ -284,11 +284,13 @@ static char *const tokenNames[COUNT_TOKEN] = {
 
 typedef enum {
 	ROLE_IMPORTED_MODULE,
+	ROLE_FOREIGNLANG_MODULE,
 	COUNT_MODULE_ROLE
 } VModuleRole;
 
 static roleDefinition VModuleRoles [COUNT_MODULE_ROLE] = {
 	{ true, "imported", "imported module" },
+	{ true, "foreignlang", "representing a foreign language (i.e., C, JS...)" },
 };
 
 typedef enum {
@@ -298,15 +300,6 @@ typedef enum {
 
 static roleDefinition VUnknownRoles [COUNT_UNKNOWN_ROLE] = {
 	{ true, "imported", "imported symbol" },
-};
-
-typedef enum {
-	ROLE_EXTERN_SYMBOL,
-	COUNT_EXTERN_ROLE
-} VExternRole;
-
-static roleDefinition VExternRoles [COUNT_EXTERN_ROLE] = {
-	{ true, "extern", "external symbol" },
 };
 
 typedef enum {
@@ -327,7 +320,6 @@ typedef enum {
 	KIND_ALIAS,
 	KIND_INTERFACE,
 	KIND_UNION,
-	KIND_EXTERN,
 	KIND_UNKNOWN,
 	COUNT_KIND
 } kindType;
@@ -350,8 +342,6 @@ static kindDefinition VKinds[COUNT_KIND] = {
 	{true, 'a', "alias", "type aliases"},
 	{true, 'i', "interface", "interfaces"},
 	{true, 'u', "union", "union names"},
-	{false, 'x', "extern", "external symbols (i.e., C, JS...)",
-	 .referenceOnly = false, ATTACH_ROLES (VExternRoles)},
 	{true, 'Y', "unknown", "unknown (imported) variables, types and functions",
 	 .referenceOnly = false, ATTACH_ROLES (VUnknownRoles)},
 };
@@ -1124,8 +1114,8 @@ static int lookupQualifiedName (tokenInfo *const token, vString *name,
 				if (!strcmp (part, "C") || !strcmp (part, "JS"))
 				{
 					external = true;
-					scope = makeTagFull (token, part, KIND_EXTERN, CORK_NIL,
-										 ROLE_EXTERN_SYMBOL, NULL, NULL, NULL);
+					scope = makeTagFull (token, part, KIND_MODULE, CORK_NIL,
+										 ROLE_FOREIGNLANG_MODULE, NULL, NULL, NULL);
 				}
 			}
 			if (!external && ongoing)


### PR DESCRIPTION
This pull request arranges the kinds and roles of V and C parsers.
I proposed two ideas:

- https://github.com/universal-ctags/ctags/pull/3795#issuecomment-1745260786
- https://github.com/universal-ctags/ctags/pull/3795#issuecomment-1751519998


```
$ cat foo.v
fn C.f(voidptr)

struct C.s {
}
$ ./ctags --sort=no --extras=+rE --fields=+rlKz -o - foo.v 
ctags: Warning: Unsupported parameter 'E' for "extras" option
C	foo.v	/^fn C.f(voidptr)$/;"	kind:module	language:V	roles:foreignlang
f	foo.v	/^fn C.f(voidptr)$/;"	kind:fn	language:V	module:C	typeref:typename:	roles:def
f	foo.v	/^fn C.f(voidptr)$/;"	kind:function	language:C	roles:foreigndecl
C	foo.v	/^struct C.s {$/;"	kind:module	language:V	roles:foreignlang
s	foo.v	/^struct C.s {$/;"	kind:struct	language:V	module:C	roles:def
s	foo.v	/^struct C.s {$/;"	kind:struct	language:C	roles:foreigndecl
```